### PR TITLE
Adds :telemetry for cache events

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ config :request_cache_plug,
   default_ttl: :timer.hours(1),
   default_concache_opts: [
     ttl_check_interval: :timer.seconds(1),
-    aquire_lock_timeout: :timer.seconds(1),
+    acquire_lock_timeout: :timer.seconds(1),
     ets_options: [write_concurrency: true, read_concurrency: true]
   ]
 ```

--- a/config/config.ex
+++ b/config/config.ex
@@ -9,6 +9,6 @@ config :request_cache,
   default_ttl: :timer.hours(1),
   default_concache_opts: [
     ttl_check_interval: :timer.seconds(1),
-    aquire_lock_timeout: :timer.seconds(1),
+    acquire_lock_timeout: :timer.seconds(1),
     ets_options: [write_concurrency: true, read_concurrency: true]
   ]

--- a/lib/request_cache/config.ex
+++ b/lib/request_cache/config.ex
@@ -31,7 +31,7 @@ defmodule RequestCache.Config do
     Application.get_env(@app, :default_concache_opts) || [
       name: :con_cache_request_cache_store,
       global_ttl: default_ttl(),
-      aquire_lock_timeout: :timer.seconds(1),
+      acquire_lock_timeout: :timer.seconds(1),
       ttl_check_interval: :timer.seconds(1),
       ets_options: [write_concurrency: true, read_concurrency: true]
     ]

--- a/lib/request_cache/metrics.ex
+++ b/lib/request_cache/metrics.ex
@@ -1,0 +1,76 @@
+defmodule RequestCache.Metrics do
+  @moduledoc false
+
+  import Telemetry.Metrics, only: [counter: 2]
+
+  @app :request_cache_plug
+  @graphql_cache_hit [@app, :graphql, :cache_hit]
+  @graphql_cache_miss [@app, :graphql, :cache_miss]
+  @rest_cache_hit [@app, :rest, :cache_hit]
+  @rest_cache_miss [@app, :rest, :cache_miss]
+  @cache_put [@app, :cache_put]
+
+  @cache_count %{count: 1}
+
+  @spec metrics() :: list(Counter.t())
+  def metrics do
+    [
+      counter(
+        counter_event_name(@graphql_cache_hit),
+        event_name: @graphql_cache_hit,
+        description: "Cache hits on GraphQL endpoints",
+        measurement: :count
+      ),
+      counter(
+        counter_event_name(@graphql_cache_miss),
+        event_name: @graphql_cache_miss,
+        description: "Cache misses on GraphQL endpoints",
+        measurement: :count
+      ),
+      counter(
+        counter_event_name(@rest_cache_hit),
+        event_name: @rest_cache_hit,
+        description: "Cache hits on REST endpoints",
+        measurement: :count
+      ),
+      counter(
+        counter_event_name(@rest_cache_miss),
+        event_name: @rest_cache_miss,
+        description: "Cache misses on REST endpoints",
+        measurement: :count
+      ),
+      counter(
+        counter_event_name(@cache_put),
+        event_name: @cache_put,
+        description: "Cache puts",
+        measurement: :count
+      )
+    ]
+  end
+
+  @spec inc_graphql_cache_hit(map()) :: :ok
+  def inc_graphql_cache_hit(metadata), do: execute(@graphql_cache_hit, @cache_count, metadata)
+
+  @spec inc_graphql_cache_miss(map()) :: :ok
+  def inc_graphql_cache_miss(metadata), do: execute(@graphql_cache_miss, @cache_count, metadata)
+
+  @spec inc_rest_cache_hit(map()) :: :ok
+  def inc_rest_cache_hit(metadata), do: execute(@rest_cache_hit, @cache_count, metadata)
+
+  @spec inc_rest_cache_miss(map()) :: :ok
+  def inc_rest_cache_miss(metadata), do: execute(@rest_cache_miss, @cache_count, metadata)
+
+  @spec inc_cache_put(map()) :: :ok
+  def inc_cache_put(metadata), do: execute(@cache_put, @cache_count, metadata)
+
+  @spec execute(keyword(), map(), map()) :: :ok
+  def execute(event_name, measurements, metadata \\ %{}) do
+    :telemetry.execute(
+      event_name,
+      measurements,
+      metadata
+    )
+  end
+
+  defp counter_event_name(event_name), do: "#{Enum.join(event_name, ".")}.total"
+end

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,9 @@ defmodule RequestCache.MixProject do
       {:plug, "~> 1.13"},
 
       {:jason, "~> 1.0", only: :test},
-      {:ex_doc, ">= 0.0.0", only: :dev}
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:telemetry, "~> 1.1"},
+      {:telemetry_metrics, "~> 0.6.1"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -12,5 +12,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "plug": {:hex, :plug, "1.13.4", "addb6e125347226e3b11489e23d22a60f7ab74786befb86c14f94fb5f23ca9a4", [:mix], [{:mime, "~> 1.0 or ~> 2.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.1.1 or ~> 1.2", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4.3 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "06114c1f2a334212fe3ae567dbb3b1d29fd492c1a09783d52f3d489c1a6f4cf2"},
   "plug_crypto": {:hex, :plug_crypto, "1.2.2", "05654514ac717ff3a1843204b424477d9e60c143406aa94daf2274fdd280794d", [:mix], [], "hexpm", "87631c7ad914a5a445f0a3809f99b079113ae4ed4b867348dd9eec288cecb6db"},
-  "telemetry": {:hex, :telemetry, "1.0.0", "0f453a102cdf13d506b7c0ab158324c337c41f1cc7548f0bc0e130bbf0ae9452", [:rebar3], [], "hexpm", "73bc09fa59b4a0284efb4624335583c528e07ec9ae76aca96ea0673850aec57a"},
+  "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
+  "telemetry_metrics": {:hex, :telemetry_metrics, "0.6.1", "315d9163a1d4660aedc3fee73f33f1d355dcc76c5c3ab3d59e76e3edf80eef1f", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "7be9e0871c41732c233be71e4be11b96e56177bf15dde64a8ac9ce72ac9834c6"},
 }

--- a/test/request_cache/metrics_test.exs
+++ b/test/request_cache/metrics_test.exs
@@ -1,0 +1,130 @@
+defmodule RequestCache.TelemetryMetricsTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+
+  alias RequestCache.Support.Utils
+
+  @expected_measurements %{count: 1}
+  @expected_rest_cache_hit_event_name [:request_cache_plug, :rest, :cache_hit]
+  @expected_rest_cache_miss_event_name [:request_cache_plug, :rest, :cache_miss]
+  @expected_graphql_cache_hit_event_name [:request_cache_plug, :graphql, :cache_hit]
+  @expected_graphql_cache_miss_event_name [:request_cache_plug, :graphql, :cache_miss]
+  @expected_cache_put_event_name [:request_cache_plug, :cache_put]
+
+  setup do: %{self: self()}
+
+  describe "GraphQL RequestCache.Plug.call/2" do
+    test "cache miss", %{self: self, test: test} do
+      start_telemetry_listener(self, test, @expected_graphql_cache_miss_event_name)
+
+      Utils.graphql_conn()
+      |> Map.put(:query_string, "?query=query any")
+      |> RequestCache.Plug.call(%{})
+
+      assert_receive {:telemetry_event, @expected_graphql_cache_miss_event_name,
+                      @expected_measurements, _metadata}
+    end
+
+    test "cache hit", %{self: self, test: test} do
+      RequestCache.ConCacheStore.put(
+        nil,
+        "/graphql:14BFE314D845C31342E288408A7DACE4",
+        1_000,
+        "TEST_VALUE"
+      )
+
+      start_telemetry_listener(self, test, @expected_graphql_cache_hit_event_name)
+
+      Utils.graphql_conn()
+      |> Map.put(:query_string, "?query=query all")
+      |> RequestCache.Plug.call(%{})
+
+      assert_receive {:telemetry_event, @expected_graphql_cache_hit_event_name,
+                      @expected_measurements, _metadata}
+    end
+  end
+
+  describe "REST RequestCache.Plug.call/2" do
+    test "cache miss", %{self: self, test: test} do
+      start_telemetry_listener(self, test, @expected_rest_cache_miss_event_name)
+
+      Utils.rest_conn()
+      |> Map.put(:query_string, "?page=1")
+      |> RequestCache.Plug.call(%{})
+
+      assert_receive {:telemetry_event, @expected_rest_cache_miss_event_name,
+                      @expected_measurements, _metadata}
+    end
+
+    test "cache hit", %{self: self, test: test} do
+      RequestCache.ConCacheStore.put(
+        nil,
+        "/entity:17CE1C08EA497571A3B6BEB378C320B1",
+        10_000,
+        "TEST_VALUE"
+      )
+
+      start_telemetry_listener(self, test, @expected_rest_cache_hit_event_name)
+
+      Utils.rest_conn()
+      |> Map.put(:query_string, "?page=2")
+      |> RequestCache.Plug.call(%{})
+
+      assert_receive {:telemetry_event, @expected_rest_cache_hit_event_name,
+                      @expected_measurements, _metadata}
+    end
+  end
+
+  describe "metrics/0" do
+    test "metric definitions are correct" do
+      assert [
+               %Telemetry.Metrics.Counter{
+                 description: "Cache hits on GraphQL endpoints",
+                 event_name: @expected_graphql_cache_hit_event_name,
+                 measurement: :count,
+                 name: @expected_graphql_cache_hit_event_name ++ [:total]
+               },
+               %Telemetry.Metrics.Counter{
+                 description: "Cache misses on GraphQL endpoints",
+                 event_name: @expected_graphql_cache_miss_event_name,
+                 measurement: :count,
+                 name: @expected_graphql_cache_miss_event_name ++ [:total]
+               },
+               %Telemetry.Metrics.Counter{
+                 description: "Cache hits on REST endpoints",
+                 event_name: @expected_rest_cache_hit_event_name,
+                 measurement: :count,
+                 name: @expected_rest_cache_hit_event_name ++ [:total]
+               },
+               %Telemetry.Metrics.Counter{
+                 description: "Cache misses on REST endpoints",
+                 event_name: @expected_rest_cache_miss_event_name,
+                 measurement: :count,
+                 name: @expected_rest_cache_miss_event_name ++ [:total]
+               },
+               %Telemetry.Metrics.Counter{
+                 description: "Cache puts",
+                 event_name: @expected_cache_put_event_name,
+                 measurement: :count,
+                 name: @expected_cache_put_event_name ++ [:total]
+               }
+             ] = RequestCache.Metrics.metrics()
+    end
+  end
+
+  defp start_telemetry_listener(self, handler_id, event_name, config \\ %{}) do
+    :telemetry.attach(
+      handler_id,
+      event_name,
+      event_handler(self),
+      config
+    )
+  end
+
+  defp event_handler(self) do
+    fn name, measurements, metadata, _config ->
+      send(self, {:telemetry_event, name, measurements, metadata})
+    end
+  end
+end

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -6,4 +6,15 @@ defmodule RequestCache.Support.Utils do
   def ensure_default_opts(conn) do
     Conn.put_private(conn, RequestCache.Config.conn_private_key(), request: RequestCache.Util.merge_default_opts([]))
   end
+
+  def graphql_conn(), do: build_conn("GET", "/graphql") |> ensure_default_opts
+
+  def rest_conn(), do: build_conn("GET", "/entity") |> ensure_default_opts
+
+  @spec build_conn(atom | binary, binary, binary | list | map | nil) :: Conn.t
+  def build_conn(method, path, params_or_body \\ nil) do
+    Plug.Adapters.Test.Conn.conn(%Conn{}, method, path, params_or_body)
+    |> Conn.put_private(:plug_skip_csrf_protection, true)
+    |> Conn.put_private(:phoenix_recycled, true)
+  end
 end


### PR DESCRIPTION
Sends the primary cache statistics (hit, miss, put) via :telemetry. 

These are global for all registered endpoints. I have a plan for allowing more granular configuration, but wanted to get the foundation in place before plumbing that through.