### PR TITLE
Fixes lookup of cache module, presented in REST endpoints

### DIFF
--- a/lib/request_cache/application.ex
+++ b/lib/request_cache/application.ex
@@ -7,8 +7,7 @@ defmodule RequestCache.Application do
 
   @impl true
   def start(_type, _args) do
-    children = [
-    ]
+    children = []
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
@@ -23,4 +22,3 @@ defmodule RequestCache.Application do
     end)
   end
 end
-

--- a/lib/request_cache/plug.ex
+++ b/lib/request_cache/plug.ex
@@ -117,7 +117,7 @@ defmodule RequestCache.Plug do
   end
 
   defp request_cache_module(conn) do
-    conn_request(conn)[:cache]
+    conn_request(conn)[:cache] || RequestCache.Config.request_cache_module()
   end
 
   defp request_cache_ttl(conn) do

--- a/test/request_cache_absinthe_test.exs
+++ b/test/request_cache_absinthe_test.exs
@@ -67,12 +67,6 @@ defmodule RequestCacheAbsintheTest do
   @query_2 "query Hello2 { helloWorld }"
   @query_error "query HelloError { helloError }"
 
-  setup_all do
-    {:ok, _pid} = RequestCache.ConCacheStore.start_link()
-
-    :ok
-  end
-
   setup do
     {:ok, pid} = EnsureCalledOnlyOnce.start_link()
 

--- a/test/request_cache_plug_test.exs
+++ b/test/request_cache_plug_test.exs
@@ -4,7 +4,7 @@ defmodule RequestCachePlugTest do
 
   import ExUnit.CaptureLog
 
-  alias RequestCache.{ConCacheStore, Support.EnsureCalledOnlyOnce}
+  alias RequestCache.Support.EnsureCalledOnlyOnce
 
   defmodule Router do
     use Plug.Router
@@ -81,8 +81,6 @@ defmodule RequestCachePlugTest do
   end
 
   test "stops any plug from running if cache is found", %{caller_pid: pid} do
-    ConCacheStore.start_link()
-
     assert %Plug.Conn{} = :get
       |> conn("/my_route")
       |> RequestCache.Support.Utils.ensure_default_opts()
@@ -108,8 +106,6 @@ defmodule RequestCachePlugTest do
   test "includes Content-Type header with value application/json from the cache", %{
     caller_pid: pid
   } do
-    ConCacheStore.start_link()
-
     assert %Plug.Conn{} =
              :get
              |> conn("/my_route")

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+RequestCache.ConCacheStore.start_link()
 ExUnit.start()


### PR DESCRIPTION
Fixes an issue where the cache store module was not being found. The issue applied only to REST endpoints. The Absinthe middleware stashes the cache module in the private section of the `Plug.Conn` where it can be looked up. The REST implementation has no hook for setting that.