### PR TITLE
tags now include labels

### DIFF
--- a/lib/request_cache/metrics.ex
+++ b/lib/request_cache/metrics.ex
@@ -19,31 +19,36 @@ defmodule RequestCache.Metrics do
         counter_event_name(@graphql_cache_hit),
         event_name: @graphql_cache_hit,
         description: "Cache hits on GraphQL endpoints",
-        measurement: :count
+        measurement: :count,
+        tags: [:labels]
       ),
       counter(
         counter_event_name(@graphql_cache_miss),
         event_name: @graphql_cache_miss,
         description: "Cache misses on GraphQL endpoints",
-        measurement: :count
+        measurement: :count,
+        tags: [:labels]
       ),
       counter(
         counter_event_name(@rest_cache_hit),
         event_name: @rest_cache_hit,
         description: "Cache hits on REST endpoints",
-        measurement: :count
+        measurement: :count,
+        tags: [:labels]
       ),
       counter(
         counter_event_name(@rest_cache_miss),
         event_name: @rest_cache_miss,
         description: "Cache misses on REST endpoints",
-        measurement: :count
+        measurement: :count,
+        tags: [:labels]
       ),
       counter(
         counter_event_name(@cache_put),
         event_name: @cache_put,
         description: "Cache puts",
-        measurement: :count
+        measurement: :count,
+        tags: [:labels]
       )
     ]
   end

--- a/test/request_cache/metrics_test.exs
+++ b/test/request_cache/metrics_test.exs
@@ -128,31 +128,36 @@ defmodule RequestCache.TelemetryMetricsTest do
           description: "Cache hits on GraphQL endpoints",
           event_name: @expected_graphql_cache_hit_event_name,
           measurement: :count,
-          name: @expected_graphql_cache_hit_event_name ++ [:total]
+          name: @expected_graphql_cache_hit_event_name ++ [:total],
+          tags: [:labels]
         },
         %Telemetry.Metrics.Counter{
           description: "Cache misses on GraphQL endpoints",
           event_name: @expected_graphql_cache_miss_event_name,
           measurement: :count,
-          name: @expected_graphql_cache_miss_event_name ++ [:total]
+          name: @expected_graphql_cache_miss_event_name ++ [:total],
+          tags: [:labels]
         },
         %Telemetry.Metrics.Counter{
           description: "Cache hits on REST endpoints",
           event_name: @expected_rest_cache_hit_event_name,
           measurement: :count,
-          name: @expected_rest_cache_hit_event_name ++ [:total]
+          name: @expected_rest_cache_hit_event_name ++ [:total],
+          tags: [:labels]
         },
         %Telemetry.Metrics.Counter{
           description: "Cache misses on REST endpoints",
           event_name: @expected_rest_cache_miss_event_name,
           measurement: :count,
-          name: @expected_rest_cache_miss_event_name ++ [:total]
+          name: @expected_rest_cache_miss_event_name ++ [:total],
+          tags: [:labels]
         },
         %Telemetry.Metrics.Counter{
           description: "Cache puts",
           event_name: @expected_cache_put_event_name,
           measurement: :count,
-          name: @expected_cache_put_event_name ++ [:total]
+          name: @expected_cache_put_event_name ++ [:total],
+          tags: [:labels]
         }
       ] = RequestCache.Metrics.metrics()
     end


### PR DESCRIPTION
The counter definitions in the Metrics module did not include the :labels which is necessary to partition the metrics by endpoint. Now they do.