### PR TITLE
Allow RequestCache.store/1 with no options

### DIFF
--- a/lib/request_cache.ex
+++ b/lib/request_cache.ex
@@ -6,7 +6,7 @@ defmodule RequestCache do
   @type opts :: [ttl: pos_integer, cache: module]
 
   @spec store(conn :: Plug.Conn.t, opts_or_ttl :: opts | pos_integer) :: Plug.Conn.t
-  def store(%Plug.Conn{} = conn, opts_or_ttl) do
+  def store(%Plug.Conn{} = conn, opts_or_ttl \\ []) do
     if RequestCache.Config.enabled?() do
       RequestCache.Plug.store_request(conn, opts_or_ttl)
     else


### PR DESCRIPTION
Allows to use the default settings without specifying an empty list as the second argument to RequestCache.store/2 