### PR TITLE
Fix compilation error when con_cache no installed

### DIFF
--- a/lib/request_cache/con_cache_store.ex
+++ b/lib/request_cache/con_cache_store.ex
@@ -34,4 +34,6 @@ cond do
 
   RequestCache.Config.request_cache_module() === RequestCache.ConCacheStore ->
     raise "Default cache is still set to RequestCache.ConCacheStore but ConCache isn't a dependency of this application\n\nEither configure a new :request_cache_module for :request_cache or add con_cache to your list of dependencies"
+
+  true -> :another_module_used
 end


### PR DESCRIPTION
Issue #14

Compilation fails when con_cache is not installed and a custom cache module is used